### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*  @blacha @Wentao-Kuang
+* @linz/proj-basemaps-dev


### PR DESCRIPTION
Use the Basemaps team as CODEOWNERS, not specific named GitHub users.