### PR TITLE
fix: Lambda exceed memory when downloading parcel, double the memory of the lambda function.

### DIFF
--- a/src/infra/__test__/lds.export.cache.test.ts
+++ b/src/infra/__test__/lds.export.cache.test.ts
@@ -32,7 +32,7 @@ describe('LdsDataCache', () => {
     const functions = findResources(synth, 'AWS::Lambda::Function');
 
     assert.equal(functions.length, 1);
-    assert.equal(functions[0]?.Properties['MemorySize'], 2048);
+    assert.equal(functions[0]?.Properties['MemorySize'], 4096);
     assert.equal(functions[0]?.Properties['Runtime'], 'nodejs20.x');
 
     // Should have a trigger set

--- a/src/infra/lds.export.cache.ts
+++ b/src/infra/lds.export.cache.ts
@@ -29,7 +29,7 @@ export class LdsExportCache extends Stack {
       entry: './src/index.ts',
       runtime: Runtime.NODEJS_20_X,
       timeout: Duration.minutes(10),
-      memorySize: 2048,
+      memorySize: 4096,
       environment: {
         CACHE_PREFIX: `s3://${cacheBucket.bucketName}`,
         KX_API_KEY: kxApiKey.stringValue,


### PR DESCRIPTION
#### Motivation

Fix the memory exceed timeout for lambda when downloading the parcel layer.

#### Modification

Double the memory of the lambda function.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
