### PR TITLE
feat: add cli to ensure all data is the latest version BM-945

### DIFF
--- a/src/cli.latest.ts
+++ b/src/cli.latest.ts
@@ -1,0 +1,44 @@
+import { S3Client } from '@aws-sdk/client-s3';
+import { fsa } from '@chunkd/fs';
+import { FsAwsS3 } from '@chunkd/fs-aws';
+import { LambdaRequest, lf } from '@linzjs/lambda';
+import { Context } from 'aws-lambda';
+import { StacCollection } from 'stac-ts';
+
+import { kx, Layers } from './config.js';
+import { cacheDataset } from './index.js';
+
+fsa.register('s3://', new FsAwsS3(new S3Client()));
+
+async function main(): Promise<void> {
+  lf.Logger.level = 'trace';
+  for (const layer of Layers.values()) {
+    if (layer.id !== 50312) continue;
+    const [s3, versions] = await Promise.all([
+      fsa.readJson<StacCollection>(new URL(`s3://linz-lds-cache/${layer.id}/collection.json`)),
+      kx.listDatasetVersions(layer.id, lf.Logger).catch(() => null),
+    ]);
+
+    if (versions == null) {
+      lf.Logger.info({ layerId: layer.id, layerName: layer.name }, 'Layer:Missing');
+      continue;
+    }
+    const latestVersion = versions[0]!;
+    const latestLink = s3.links.at(-1)!;
+
+    const isLatest = latestLink.href.includes(String(latestVersion.id));
+    const currentVersion = latestLink.href.split('_').at(-1)?.replace('.json', '');
+
+    if (!isLatest) {
+      lf.Logger.warn(
+        { layerId: layer.id, layerName: layer.name, versionId: latestVersion.id, currentVersion },
+        'Layer:Version:Old',
+      );
+      await cacheDataset(new LambdaRequest({}, {} as Context, lf.Logger), layer.id);
+    } else {
+      lf.Logger.info({ layerId: layer.id, layerName: layer.name }, 'Layer:Version:Ok');
+    }
+  }
+}
+
+main();

--- a/src/cli.latest.ts
+++ b/src/cli.latest.ts
@@ -13,7 +13,6 @@ fsa.register('s3://', new FsAwsS3(new S3Client()));
 async function main(): Promise<void> {
   lf.Logger.level = 'trace';
   for (const layer of Layers.values()) {
-    if (layer.id !== 50312) continue;
     const [s3, versions] = await Promise.all([
       fsa.readJson<StacCollection>(new URL(`s3://linz-lds-cache/${layer.id}/collection.json`)),
       kx.listDatasetVersions(layer.id, lf.Logger).catch(() => null),

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ const MaxExports = isNaN(MaxExportsEnv) ? 5 : MaxExportsEnv;
 
 const eb = new AwsEventBridgeBus();
 
-async function cacheDataset(req: LambdaRequest, datasetId: number): Promise<void> {
+export async function cacheDataset(req: LambdaRequest, datasetId: number): Promise<void> {
   const [latestVersion] = await kx.listDatasetVersions(datasetId, req.log);
   // Could not find the dataset ignore
   if (latestVersion == null) {

--- a/src/kx.ts
+++ b/src/kx.ts
@@ -194,6 +194,7 @@ export class KxApi {
   }
 
   private async get(uri: string, queryString: QueryRecord = {}, logger: LogType, backOff = 0): Promise<Response> {
+    const startTime = performance.now();
     const urlParams = new URLSearchParams();
     for (const [key, value] of Object.entries(queryString)) {
       if (value == null) continue;
@@ -212,7 +213,8 @@ export class KxApi {
       await new Promise((resolve) => setTimeout(resolve, BackOffMs * backOff));
       return this.get(uri, queryString, logger, backOff);
     }
-    logger?.info({ url, status: res.status }, 'Fetch:Done');
+    const duration = performance.now() - startTime;
+    logger?.info({ url, status: res.status, duration }, 'Fetch:Done');
 
     if (!res.ok) throw new Error(`Failed to fetch: ${res.status}: ${res.statusText}`);
 


### PR DESCRIPTION
#### Motivation

Sometimes the LDS layer cache gets out of sync, as it is monitoring the "changed dataset" list, if this list gets updated too frequently it can miss some updates.

#### Modification

Adds a CLI to validate the LDS Cache is still in sync

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
