### PR TITLE
fix: disable 53382-nz-roads-addressing until EOF error is fixed BM-1070

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -424,7 +424,8 @@ const Monitor = [
   { id: 52309, name: '52309-cook-islands-tree-points-topo-125k-zone3' },
   { id: 52310, name: '52310-cook-islands-wharf-centrelines-topo-125k-zone3' },
   { id: 52390, name: '52390-nz-campbell-island-motu-ihupuku-rock-points-topo-150k' },
-  { id: 53382, name: '53382-nz-roads-addressing' },
+  // TODO: re-enable this when BM-1070 is fixed
+  // { id: 53382, name: '53382-nz-roads-addressing' },
 ];
 
 export const Layers = new Map<number, { id: number; name: string }>();


### PR DESCRIPTION
#### Motivation

We are seeing some EOF errors when unzipping the export archive for nz-roads-addressing, we do not currently use this layer so disable it until we can figure out how to fix the EOFs

#### Modification

Disable layer 53382

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
