### PR TITLE
fix: cdk deploy is broken

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -1,3 +1,3 @@
 {
-  "app": "node build/src/infra/index.js"
+  "app": "node src/infra/index.ts"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@types/aws-lambda": "^8.10.83",
         "@types/geojson": "^7946.0.8",
         "@types/node": "^20.10.4",
-        "aws-cdk": "^2.115.0",
+        "aws-cdk": "^2.1004.0",
         "constructs": "^10.4.2",
         "esbuild": "^0.19.9"
       }
@@ -3210,10 +3210,11 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.115.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.115.0.tgz",
-      "integrity": "sha512-jf+5j+ygk/DqxLzYyjFnCOOlRgvL/fwcYhyanhpb1OEQEe1FF6NGUb1TYsnQc3Ly67qLOKkQgdeyeXgzkKoSOQ==",
+      "version": "2.1004.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1004.0.tgz",
+      "integrity": "sha512-3E5ICmSc7ZCZCwLX7NY+HFmmdUYgRaL+67h/BDoDQmkhx9StC8wG4xgzHFY9k8WQS0+ib/MP28f2d9yzHtQLlQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "cdk": "bin/cdk"
       },
@@ -4700,6 +4701,7 @@
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@types/aws-lambda": "^8.10.83",
     "@types/geojson": "^7946.0.8",
     "@types/node": "^20.10.4",
-    "aws-cdk": "^2.115.0",
+    "aws-cdk": "^2.1004.0",
     "constructs": "^10.4.2",
     "esbuild": "^0.19.9"
   },


### PR DESCRIPTION
#### Motivation

As part of the move to nodejs23 typescript no longer outputs `build/**` the cdk.json was looking for a `build/src/infra/index.js` that no longer exists

#### Modification

Move CDK to use `src/infra/index.ts`
Upgraded aws-cdk to latest version as it had conflicts

#### Verification

Deployed into nonprod to validate the deployment process.