### PR TITLE
build: Reset github token for release please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,6 +7,8 @@ name: release-please
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    environment:
+      name: prod
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
     steps:
@@ -14,7 +16,7 @@ jobs:
         id: release
         with:
           release-type: node
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.LI_GITHUB_ACTION_TOKEN }}
 
   publish-release:
     needs: release-please


### PR DESCRIPTION
#### Motivation
`release-please` has been blocked by security team, and to enable it we will need to setup PAT for them via `linz-li-bot` account.  


#### Modification

- We have setup the `linz-li-bot` secrets in https://github.com/linz/github-tf/blob/2034c5aa1364473446cff6be2d81d3250fa6dac4/src/repo/repo.lds.cache.ts#L14C11-L14C23
- Update the code changes to point to the new secrets


#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
